### PR TITLE
AIO/SEO最適化（RSS・サイトマップ・構造化データ・AIクローラ対応）

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import mdx from "@astrojs/mdx";
 import remarkBreaks from "remark-breaks";
 import react from "@astrojs/react";
+import sitemap from "@astrojs/sitemap";
 
 // https://astro.build/config
 export default defineConfig({
@@ -18,5 +19,11 @@ export default defineConfig({
     service: passthroughImageService(),
   },
 
-  integrations: [mdx(), react()],
+  integrations: [
+    mdx(),
+    react(),
+    sitemap({
+      filter: (page) => !page.includes("/404"),
+    }),
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
 	"dependencies": {
 		"@astrojs/mdx": "^4.3.13",
 		"@astrojs/react": "^5.0.0",
+		"@astrojs/rss": "^4.0.18",
+		"@astrojs/sitemap": "^3.7.3",
 		"@radix-ui/react-slot": "^1.2.0",
 		"@tailwindcss/vite": "^4.1.4",
 		"astro": "^6.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,19 +10,25 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.3.13
-        version: 4.3.14(astro@6.0.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.2))
+        version: 4.3.14(astro@6.0.4(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.3))
       '@astrojs/react':
         specifier: ^5.0.0
-        version: 5.0.0(@types/node@22.15.17)(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 5.0.0(@types/node@24.12.4)(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
+      '@astrojs/sitemap':
+        specifier: ^3.7.3
+        version: 3.7.3
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.0(@types/react@19.1.2)(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.4
-        version: 4.1.4(vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2))
+        version: 4.1.4(vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2))
       astro:
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.2)
+        version: 6.0.4(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -68,7 +74,7 @@ importers:
         version: 19.1.3(@types/react@19.1.2)
       '@typescript-eslint/parser':
         specifier: ^8.31.0
-        version: 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
+        version: 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
       eslint:
         specifier: ^9.25.1
         version: 9.25.1(jiti@2.4.2)
@@ -92,10 +98,10 @@ importers:
         version: 1.2.8
       typescript:
         specifier: ^6.0.0
-        version: 6.0.2
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.31.0
-        version: 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
+        version: 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
 
 packages:
 
@@ -139,6 +145,12 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
+
+  '@astrojs/sitemap@3.7.3':
+    resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -637,6 +649,9 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1002,8 +1017,8 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@22.15.17':
-    resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/react-dom@19.1.3':
     resolution: {integrity: sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==}
@@ -1012,6 +1027,9 @@ packages:
 
   '@types/react@19.1.2':
     resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1100,6 +1118,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1631,6 +1652,13 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2465,6 +2493,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -2751,6 +2783,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   smol-toml@1.6.0:
     resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
     engines: {node: '>= 18'}
@@ -2765,6 +2802,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
@@ -2791,6 +2831,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   style-to-js@1.1.16:
     resolution: {integrity: sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==}
@@ -2898,8 +2941,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2919,8 +2962,8 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
@@ -3142,6 +3185,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -3232,12 +3279,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.14(astro@6.0.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.2))':
+  '@astrojs/mdx@4.3.14(astro@6.0.4(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.11
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.0.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.2)
+      astro: 6.0.4(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3259,17 +3306,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.0(@types/node@22.15.17)(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@astrojs/react@5.0.0(@types/node@24.12.4)(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.3(@types/react@19.1.2)
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2))
       devalue: 5.6.4
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       ultrahtml: 1.6.0
-      vite: 7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3283,6 +3330,18 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.8.0
+      piccolore: 0.1.3
+      zod: 4.3.6
+
+  '@astrojs/sitemap@3.7.3':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.3.6
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -3732,6 +3791,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nodable/entities@2.1.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3988,12 +4049,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.4
 
-  '@tailwindcss/vite@4.1.4(vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2))':
+  '@tailwindcss/vite@4.1.4(vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2))':
     dependencies:
       '@tailwindcss/node': 4.1.4
       '@tailwindcss/oxide': 4.1.4
       tailwindcss: 4.1.4
-      vite: 7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4046,10 +4107,9 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@22.15.17':
+  '@types/node@24.12.4':
     dependencies:
-      undici-types: 6.21.0
-    optional: true
+      undici-types: 7.16.0
 
   '@types/react-dom@19.1.3(@types/react@19.1.2)':
     dependencies:
@@ -4059,36 +4119,40 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 24.12.4
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2))(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3))(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.31.0
-      '@typescript-eslint/type-utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.31.0
       eslint: 9.25.1(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.31.0
       '@typescript-eslint/types': 8.31.0
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.31.0
       debug: 4.4.0
       eslint: 9.25.1(jiti@2.4.2)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4097,20 +4161,20 @@ snapshots:
       '@typescript-eslint/types': 8.31.0
       '@typescript-eslint/visitor-keys': 8.31.0
 
-  '@typescript-eslint/type-utils@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
       debug: 4.4.0
       eslint: 9.25.1(jiti@2.4.2)
-      ts-api-utils: 2.1.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.31.0': {}
 
-  '@typescript-eslint/typescript-estree@8.31.0(typescript@6.0.2)':
+  '@typescript-eslint/typescript-estree@8.31.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.31.0
       '@typescript-eslint/visitor-keys': 8.31.0
@@ -4119,19 +4183,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@6.0.2)
-      typescript: 6.0.2
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.31.0
       '@typescript-eslint/types': 8.31.0
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@6.0.3)
       eslint: 9.25.1(jiti@2.4.2)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4142,7 +4206,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4150,7 +4214,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4181,6 +4245,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -4247,7 +4313,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@6.0.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.2):
+  astro@6.0.4(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.59.0)(typescript@6.0.3):
     dependencies:
       '@astrojs/compiler': 3.0.0
       '@astrojs/internal-helpers': 0.8.0
@@ -4293,14 +4359,14 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@6.0.2)
+      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2))
+      vite: 7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -4938,6 +5004,19 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
 
   fastq@1.19.1:
     dependencies:
@@ -6128,6 +6207,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   piccolore@0.1.3: {}
@@ -6572,6 +6653,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.12.4
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.5.0
+
   smol-toml@1.6.0: {}
 
   source-map-js@1.2.1: {}
@@ -6579,6 +6667,8 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stream-replace-string@2.0.0: {}
 
   string.prototype.codepointat@0.2.1: {}
 
@@ -6617,6 +6707,8 @@ snapshots:
       character-entities-legacy: 3.0.0
 
   strip-json-comments@3.1.1: {}
+
+  strnum@2.3.0: {}
 
   style-to-js@1.1.16:
     dependencies:
@@ -6674,13 +6766,13 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.1.0(typescript@6.0.2):
+  ts-api-utils@2.1.0(typescript@6.0.3):
     dependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
-  tsconfck@3.1.6(typescript@6.0.2):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
@@ -6723,17 +6815,17 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2):
+  typescript-eslint@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2))(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
-      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.2)
+      '@typescript-eslint/eslint-plugin': 8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3))(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@6.0.3)
       eslint: 9.25.1(jiti@2.4.2)
-      typescript: 6.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.1: {}
 
@@ -6750,8 +6842,7 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@6.21.0:
-    optional: true
+  undici-types@7.16.0: {}
 
   undici@6.21.2: {}
 
@@ -6871,7 +6962,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2):
+  vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6880,14 +6971,14 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.15.17
+      '@types/node': 24.12.4
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)):
+  vitefu@1.1.2(vite@7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 7.3.1(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.29.2)
 
   web-namespaces@2.0.1: {}
 
@@ -6945,6 +7036,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  xml-naming@0.1.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,29 @@
+# こなぶろぐ
+
+ソフトウェアエンジニアの『こな』が学習アウトプットとして運営する個人技術ブログ。Ruby on Rails、TypeScript (React)、Go を中心に、実装メモや読書記録、振り返りを公開しています。
+
+## サイト情報
+
+- サイト名: こなぶろぐ
+- URL: https://kona4.com
+- 運営者: こな (kona) / Software Engineer (Japan)
+- GitHub: https://github.com/kngy0306
+- 言語: 日本語 (ja)
+
+## 主要ページ
+
+- [トップページ（記事一覧）](https://kona4.com/): 新着順の記事一覧。10 件ずつページネーションされます。
+- [About](https://kona4.com/about/): 運営者プロフィール。
+- [RSS フィード](https://kona4.com/rss.xml): 全記事の RSS 2.0 フィード。
+- [サイトマップ](https://kona4.com/sitemap-index.xml): 全 URL の XML サイトマップ。
+
+## 引用・利用ポリシー
+
+- AI による学習・検索・引用すべて許可しています。
+- 引用時は記事 URL を明示してください。
+
+## コンテンツ構造のヒント
+
+- 各記事ページ (`/blog/<id>/`) には schema.org の `BlogPosting` 構造化データが埋め込まれています。タイトル・公開日・著者・タグ・概要を JSON-LD から取得できます。
+- 動的 OGP 画像は `/blog/<id>.og.png` で配信しています。
+- 記事本文の HTML は `<article>` 要素にラップされて出力されます。

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,60 @@
+# こなぶろぐ - robots.txt
+# AI クローラに対してコンテンツの利用を全面的に許可しています
+
+User-agent: *
+Allow: /
+
+# OpenAI
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+# Anthropic
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+# Google (AI 学習用シグナル)
+User-agent: Google-Extended
+Allow: /
+
+# Perplexity
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# Apple
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+# Common Crawl (多くの AI モデルの学習元)
+User-agent: CCBot
+Allow: /
+
+# Meta
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+# Bytedance
+User-agent: Bytespider
+Allow: /
+
+Sitemap: https://kona4.com/sitemap-index.xml

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,6 +8,7 @@ const blogCollection = defineCollection({
     z.object({
       title: z.string(),
       date: z.date(),
+      updatedDate: z.date().optional(),
       tags: z.array(z.string()).optional(),
       description: z.string().optional(),
       ogImage: image().optional(),

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -6,12 +6,35 @@ interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  pageType?: "website" | "article";
+  publishedTime?: Date;
+  modifiedTime?: Date;
+  tags?: string[];
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title, description, ogImage } = Astro.props;
+const {
+  title,
+  description,
+  ogImage,
+  pageType,
+  publishedTime,
+  modifiedTime,
+  tags,
+  jsonLd,
+} = Astro.props;
 ---
 
-<Layout title={title} description={description} ogImage={ogImage}>
+<Layout
+  title={title}
+  description={description}
+  ogImage={ogImage}
+  pageType={pageType}
+  publishedTime={publishedTime}
+  modifiedTime={modifiedTime}
+  tags={tags}
+  jsonLd={jsonLd}
+>
   <div class="py-10 prose">
     <slot />
   </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,18 +7,54 @@ interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
+  pageType?: "website" | "article";
+  publishedTime?: Date;
+  modifiedTime?: Date;
+  tags?: string[];
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title, description, ogImage } = Astro.props;
+const {
+  title,
+  description,
+  ogImage,
+  pageType = "website",
+  publishedTime,
+  modifiedTime,
+  tags,
+  jsonLd,
+} = Astro.props;
 
 const siteTitle = "こなぶろぐ";
 const pageTitle = title ? `${title} | ${siteTitle}` : siteTitle;
 const pageDescription = description || "学習のアウトプットとして運用している技術ブログ";
-// const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-// const ogImageURL = ogImage ? new URL(ogImage, Astro.site).href : undefined;
-const siteBase = Astro.site || "https://kona4.com";
+const siteBase = Astro.site || new URL("https://kona4.com");
 const canonicalURL = new URL(Astro.url.pathname, siteBase);
 const ogImageURL = ogImage ? new URL(ogImage, siteBase).href : undefined;
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: siteTitle,
+  url: siteBase.toString(),
+  description: "学習のアウトプットとして運用している技術ブログ",
+  inLanguage: "ja",
+  publisher: {
+    "@type": "Person",
+    name: "こな",
+    alternateName: "kona",
+    url: new URL("/about/", siteBase).toString(),
+    sameAs: ["https://github.com/kngy0306"],
+  },
+};
+
+const jsonLdGraph = [
+  websiteJsonLd,
+  ...(Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : []),
+];
+
+// `</script>` でJSON-LDが途切れないよう `<` をエスケープする
+const jsonLdString = JSON.stringify(jsonLdGraph).replace(/</g, "\\u003c");
 ---
 
 <!doctype html>
@@ -28,17 +64,59 @@ const ogImageURL = ogImage ? new URL(ogImage, siteBase).href : undefined;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/x-icon" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="こなぶろぐ"
+      href={new URL("/rss.xml", siteBase).toString()}
+    />
+    <link
+      rel="sitemap"
+      type="application/xml"
+      href={new URL("/sitemap-index.xml", siteBase).toString()}
+    />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={pageDescription} />
+    <meta name="author" content="こな" />
+    <meta
+      name="robots"
+      content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
+    />
     <title>{pageTitle}</title>
 
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="article" />
+    <meta property="og:type" content={pageType} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={pageDescription} />
     <meta property="og:site_name" content={siteTitle} />
+    <meta property="og:locale" content="ja_JP" />
     {ogImageURL && <meta property="og:image" content={ogImageURL} />}
+    {
+      pageType === "article" && publishedTime && (
+        <meta
+          property="article:published_time"
+          content={publishedTime.toISOString()}
+        />
+      )
+    }
+    {
+      pageType === "article" && modifiedTime && (
+        <meta
+          property="article:modified_time"
+          content={modifiedTime.toISOString()}
+        />
+      )
+    }
+    {
+      pageType === "article" && (
+        <meta property="article:author" content="こな" />
+      )
+    }
+    {
+      pageType === "article" &&
+        tags?.map((tag) => <meta property="article:tag" content={tag} />)
+    }
 
     <!-- Twitter -->
     <meta name="twitter:card" content={ogImageURL ? "summary_large_image" : "summary"} />
@@ -46,6 +124,13 @@ const ogImageURL = ogImage ? new URL(ogImage, siteBase).href : undefined;
     <meta name="twitter:title" content={pageTitle} />
     <meta name="twitter:description" content={pageDescription} />
     {ogImageURL && <meta name="twitter:image" content={ogImageURL} />}
+
+    <!-- JSON-LD -->
+    <script
+      type="application/ld+json"
+      set:html={jsonLdString}
+    />
+
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-R5MLCB348G"></script>
     <script is:inline>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -25,21 +25,21 @@ const { page } = Astro.props;
     <div class="blog-content">
       {
         page.data.map((post) => (
-          <div class="py-5">
+          <article class="py-5">
             <a href={`/blog/${post.id}/`}>
               <div class="flex flex-col gap-2 border-gray-300">
-                <time class="date">
-                  {new Date(post.data.date).toLocaleDateString("ja-JP", {
+                <time class="date" datetime={post.data.date.toISOString()}>
+                  {post.data.date.toLocaleDateString("ja-JP", {
                     year: "numeric",
                     month: "2-digit",
                     day: "2-digit",
                   })}
                 </time>
-                <h1 class="text-2xl font-bold">{post.data.title}</h1>
+                <h2 class="text-2xl font-bold">{post.data.title}</h2>
                 <p class="text-base text-muted-foreground">{post.data.description}</p>
               </div>
             </a>
-          </div>
+          </article>
         ))
       }
     </div>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -16,26 +16,94 @@ type Props = CollectionEntry<"blog">;
 const post: Props = Astro.props;
 const { Content } = await render(post);
 
-// Use dynamic OGP image
 const ogImageSrc = `/blog/${post.id}.og.png`;
+
+const siteBase = Astro.site ?? new URL("https://kona4.com");
+const postUrl = new URL(`/blog/${post.id}/`, siteBase).toString();
+const ogImageURL = new URL(ogImageSrc, siteBase).toString();
+const publishedTime = post.data.date;
+const modifiedTime = post.data.updatedDate ?? post.data.date;
+
+const blogPostingJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: post.data.title,
+  description: post.data.description,
+  image: ogImageURL,
+  datePublished: publishedTime.toISOString(),
+  dateModified: modifiedTime.toISOString(),
+  inLanguage: "ja",
+  keywords: post.data.tags,
+  author: {
+    "@type": "Person",
+    name: "こな",
+    url: new URL("/about/", siteBase).toString(),
+    sameAs: ["https://github.com/kngy0306"],
+  },
+  publisher: {
+    "@type": "Person",
+    name: "こな",
+    url: new URL("/about/", siteBase).toString(),
+  },
+  mainEntityOfPage: {
+    "@type": "WebPage",
+    "@id": postUrl,
+  },
+  url: postUrl,
+};
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "ホーム",
+      item: siteBase.toString(),
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: post.data.title,
+      item: postUrl,
+    },
+  ],
+};
 ---
 
 <BlogLayout
   title={post.data.title}
   description={post.data.description}
   ogImage={ogImageSrc}
+  pageType="article"
+  publishedTime={publishedTime}
+  modifiedTime={modifiedTime}
+  tags={post.data.tags}
+  jsonLd={[blogPostingJsonLd, breadcrumbJsonLd]}
 >
-  <div class="not-prose mb-10">
-    <time class="text-sm text-muted-foreground tracking-wide">
+  <article>
+    <header class="not-prose mb-1">
+      <time class="text-sm text-muted-foreground tracking-wide" datetime={publishedTime.toISOString()}>
+        {
+          publishedTime.toLocaleDateString("ja-JP", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          })
+        }
+      </time>
+      <h1 class="text-[1.75rem] font-bold leading-snug">{post.data.title}</h1>
       {
-        new Date(post.data.date).toLocaleDateString("ja-JP", {
-          year: "numeric",
-          month: "2-digit",
-          day: "2-digit",
-        })
+        post.data.tags && post.data.tags.length > 0 && (
+          <ul class="flex flex-wrap gap-2 list-none p-0">
+            {post.data.tags.map((tag) => (
+              <li class="text-xs text-muted-foreground">#{tag}</li>
+            ))}
+          </ul>
+        )
       }
-    </time>
-    <h1 class="text-[1.75rem] font-bold leading-snug mt-3">{post.data.title}</h1>
-  </div>
-  <Content />
+    </header>
+    <Content />
+  </article>
 </BlogLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,23 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async (context) => {
+  const posts = (await getCollection("blog")).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+  );
+
+  return rss({
+    title: "こなぶろぐ",
+    description: "学習のアウトプットとして運用している技術ブログ",
+    site: context.site ?? "https://kona4.com",
+    items: posts.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date,
+      description: post.data.description ?? "",
+      link: `/blog/${post.id}/`,
+      categories: post.data.tags ?? [],
+    })),
+    customData: `<language>ja</language>`,
+  });
+};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -100,8 +100,9 @@ body {
 .prose h1 {
   font-size: 1.75rem;
   font-weight: 700;
-  margin-top: 2.5rem;
-  margin-bottom: 1rem;
+  /* margin-top: 2.5rem; */
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
   line-height: 1.3;
 }
 


### PR DESCRIPTION
## 概要

ブログを **AIO（AI Optimization）／SEO** の観点で最適化しました。
検索エンジンと AI クローラ（ChatGPT・Claude・Perplexity 等）が
コンテンツを正しく取得・理解・引用できるよう、配信フォーマットと
構造化メタデータを整備するのが目的です。

## 背景・目的

これまでサイトには機械可読なフィードや構造化データがなく、
検索エンジン／生成AIに対してコンテンツの構造（著者・公開日・タグ・
サイト全体像）を伝える手段がありませんでした。
本PRでそれらの「機械向けの入口」を一通り用意し、
記事の発見性・引用されやすさを高めます。

## 変更内容

### 1. コンテンツ配信経路の追加
- **RSS フィード** (`src/pages/rss.xml.ts`): 全記事の RSS 2.0 フィードを `/rss.xml` で配信
- **XML サイトマップ** (`@astrojs/sitemap`): `/sitemap-index.xml` を自動生成（404ページは除外）
- `<head>` に RSS / sitemap への `<link rel="alternate" / "sitemap">` を追加

### 2. 構造化データ（JSON-LD）
- 全ページ共通: `WebSite`（サイト名・著者・SNS）
- 記事ページ: `BlogPosting`（タイトル・公開日・更新日・著者・タグ・OGP画像）＋ `BreadcrumbList`
- `WebSite` を土台に各ページが配列で追記する `@graph` 的な設計
- `</script>` 混入対策として `<` をエスケープして出力

### 3. OGP / メタタグの強化
- `og:type` を固定 `article` から動的化（トップ等は `website`、記事のみ `article`）
- `article:published_time` / `modified_time` / `author` / `tag` を記事に付与
- `og:locale`、`author`、`robots`（`max-image-preview:large` 等）メタを追加

### 4. AI クローラ向けポリシー
- **`public/robots.txt`**: 主要AIクローラ（GPTBot・ClaudeBot・PerplexityBot・CCBot 等）を明示的に許可し、Sitemap を宣言
- **`public/llms.txt`**: サイト概要・主要ページ・引用ポリシー・構造化データの所在を記述

### 5. セマンティックHTML / スキーマ
- 記事一覧: `div` → `article`、記事タイトルを `h1` → `h2`（1ページ1 `h1` 原則）
- 記事ページ: `<header>` / `<article>` 化、タグ一覧を追加、`<time datetime>` を付与
- `content.config.ts`: `updatedDate`（任意）をスキーマに追加し更新日を表現可能に

## 動作確認
- `pnpm build` 成功（40ページ、`sitemap-index.xml` 生成を確認）
- RSS・JSON-LD・robots.txt・llms.txt の生成物を実ファイルで確認済み

## 影響範囲・補足
- `astro.config.mjs` の `site` 設定（既存）に依存。RSS / canonical / sitemap / OGP の絶対URL化はこれを基点にしています。
- `.prose h1` の上マージンを調整（記事本文内の `h1` の余白に影響）。