### PR TITLE
Migrate to Astro font provider for Noto Sans JP

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,9 @@
 // @ts-check
-import { defineConfig, passthroughImageService } from "astro/config";
+import {
+  defineConfig,
+  fontProviders,
+  passthroughImageService,
+} from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import mdx from "@astrojs/mdx";
 import remarkBreaks from "remark-breaks";
@@ -25,5 +29,13 @@ export default defineConfig({
     sitemap({
       filter: (page) => !page.includes("/404"),
     }),
+  ],
+
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: "Noto Sans JP",
+      cssVariable: "--font-noto-sans-jp",
+    },
   ],
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -63,7 +63,7 @@ const jsonLdString = JSON.stringify(jsonLdGraph).replace(/</g, "\\u003c");
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <Font cssVariable="--font-noto-sans-jp" preload />
+    <Font cssVariable="--font-noto-sans-jp" />
     <link rel="icon" type="image/x-icon" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
     <link

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { Font } from "astro:assets";
 import "@/styles/global.css";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
@@ -62,6 +63,7 @@ const jsonLdString = JSON.stringify(jsonLdGraph).replace(/</g, "\\u003c");
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
+    <Font cssVariable="--font-noto-sans-jp" preload />
     <link rel="icon" type="image/x-icon" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
     <link

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @import "tw-animate-css";
@@ -8,7 +7,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: "Noto Sans JP", sans-serif;
+  font-family: var(--font-noto-sans-jp), sans-serif;
 }
 
 @theme inline {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,10 +7,11 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: var(--font-noto-sans-jp), sans-serif;
 }
 
 @theme inline {
+  --default-font-family: var(--font-noto-sans-jp), sans-serif;
+  --font-sans: var(--font-noto-sans-jp), sans-serif;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);


### PR DESCRIPTION
# 概要

Astro 6 の Font API を利用して、Google Fonts CDN からの外部読み込みをセルフホスティング方式に移行

closes [#30](https://github.com/kngy0306/myblog/issues/30)

## 変更内容

- astro.config.mjs
  - fontProviders.google() で Noto Sans JP を Font API 経由で設定
  - CSS変数 --font-noto-sans-jp を定義
- [src/layouts/Layout.astro](https://github.com/kngy0306/myblog/blob/claude/implement-issue-30-2tMAd/src/layouts/Layout.astro)
  - <Font> コンポーネント（astro:assets）を <head> 内に追加
  - CJKフォントはunicode-rangeサブセットが多数あるため、preload は指定しない（オンデマンド読み込み）
- [src/styles/global.css](https://github.com/kngy0306/myblog/blob/claude/implement-issue-30-2tMAd/src/styles/global.css)
  - Google Fonts の @import url(...) を削除
  - body の font-family 直指定を削除
  - Tailwind CSS v4 の @theme inline で --default-font-family と --font-sans に Font API の CSS変数を設定

## 効果

- プライバシー向上: Google Fonts CDN への外部リクエストが不要に
- パフォーマンス: 外部ドメインへのDNSルックアップ・TLS接続コストを削減
- フォント最適化: Astro が自動的にフォールバックフォントを生成し、レイアウトシフト（CLS）を軽減